### PR TITLE
To support GPU acceleration using MPS in MacOS

### DIFF
--- a/detectionmetrics/models/torch.py
+++ b/detectionmetrics/models/torch.py
@@ -313,13 +313,15 @@ class TorchImageSegmentationModel(dm_model.ImageSegmentationModel):
         :type ontology_fname: str
         """
         # Get device (CPU or GPU)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda" if torch.cuda.is_available() else 
+                                "mps" if torch.backends.mps.is_available() else 
+                                "cpu")
 
         # If 'model' contains a string, check that it is a valid filename and load model
         if isinstance(model, str):
             assert os.path.isfile(model), "TorchScript Model file not found"
             model_fname = model
-            model = torch.jit.load(model)
+            model = torch.jit.load(model, map_location=self.device)
             model_type = "compiled"
         # Otherwise, check that it is a PyTorch module
         elif isinstance(model, torch.nn.Module):

--- a/detectionmetrics/models/torch.py
+++ b/detectionmetrics/models/torch.py
@@ -556,13 +556,15 @@ class TorchLiDARSegmentationModel(dm_model.LiDARSegmentationModel):
         :type ontology_fname: str
         """
         # Get device (CPU or GPU)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device("cuda" if torch.cuda.is_available() else 
+                                    "mps" if torch.backends.mps.is_available() else 
+                                    "cpu")
 
         # If 'model' contains a string, check that it is a valid filename and load model
         if isinstance(model, str):
             assert os.path.isfile(model), "TorchScript Model file not found"
             model_fname = model
-            model = torch.jit.load(model)
+            model = torch.jit.load(model, map_location=self.device)
             model_type = "compiled"
         # Otherwise, check that it is a PyTorch module
         elif isinstance(model, torch.nn.Module):


### PR DESCRIPTION
Earlier DetectionMetrics was only using CUDA for gpu acceleration. But that isnt supported in macos, I have modified the condition where MPS is used in the absence of CUDA, only in the absence of MPS or CUDA, CPU is used.  Also added map_location argument in torch.jit.load() to avoid errors due to device mismatch. This change improves cross-platform compatibility of DetectionMetrics. 

Tested in MacOS using [tutorial_image_segmentation.ipynb](https://github.com/JdeRobot/DetectionMetrics/blob/master/examples/tutorial_image_segmentation.ipynb). Improved the test run time from 7minutes(Using CPU) to 2minutes 30 seconds(Using MPS).