### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ In the near future, *DetectionMetrics* is planned to be deployed in PyPI. In the
 ### Using venv
 Create your virtual environment:
 ```
-mkdir .venv
 python3 -m venv .venv
 ```
 


### PR DESCRIPTION
There's no need for `mkdir .venv` as ` python -m venv <folder name> ` this folder is automatically created by python so `mkdir .venv ` is redundant command here.