### PR TITLE
Added github actions for automatically running tests.

### DIFF
--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -1,0 +1,26 @@
+name: Run tests automatically
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: python -m pip install pytest .
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
Closes #292 
I have added github action for running tests automatically. Based on the other action [build-sphinx-docs.yml](https://github.com/JdeRobot/DetectionMetrics/blob/master/.github/workflows/build-sphinx-docs.yml) , I am running the tests only on ubuntu-latest and python version 3.10 for now.

But in my opinion we should be running on multiple operating systems and on a bunch of python versions isn't it? I can add the matrix and modify the code if you want me to. Let me know if you think that is an overkill.