### PR TITLE
Added: Caching in CI/CD workflow 

### DIFF
--- a/.github/workflows/build-sphinx-docs.yml
+++ b/.github/workflows/build-sphinx-docs.yml
@@ -22,7 +22,15 @@ jobs:
        uses: actions/setup-python@v5
        with:
          python-version: '3.10'
+         cache: 'pip'  
 
+     - name: Cache Sphinx build
+       uses: actions/cache@v3
+       with:
+        path: docs/py_docs/_build
+        key: ${{ runner.os }}-sphinx-${{ hashFiles('docs/py_docs/**') }}
+        restore-keys: |
+         ${{ runner.os }}-sphinx-
 
      - name: Install dependencies
        run: |

--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -18,6 +18,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'  
+
+      - name: Cache pytest
+        uses: actions/cache@v3
+        with:
+          path: |
+            .pytest_cache
+            __pycache__
+          key: ${{ runner.os }}-pytest-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pytest-
 
       - name: Install dependencies
         run: python -m pip install pytest .


### PR DESCRIPTION
I have added Cache in github actions which significantly improve workflow, now action 
![image](https://github.com/user-attachments/assets/52e93762-2a12-4658-8dbb-3a52e54a88f8)
Dont have to download this 600mb+ of data every time, unless any significant changes are made 
